### PR TITLE
Implement create for experiences

### DIFF
--- a/app/controllers/api/v1/experiences_controller.rb
+++ b/app/controllers/api/v1/experiences_controller.rb
@@ -19,6 +19,16 @@ module Api
         head :no_content
       end
 
+      def create
+        @experience = current_person.hosted_experiences.new experience_params
+
+        if @experience.save
+          render json: @experience, status: :created
+        else
+          render json: @experience.errors, status: :unprocessable_entity
+        end
+      end
+
       private
 
       def set_experience
@@ -26,7 +36,12 @@ module Api
       end
 
       def experience_params
-        params.permit :id, :page, :name, :experience
+        params.require(:experience).permit(
+          :name,
+          :location,
+          :description,
+          :experience_times
+        )
       end
     end
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -15,10 +15,12 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  def verify_jwt_token
-    token = extract_token_from_headers request.headers
+  def user_token
+    extract_token_from_headers request.headers
+  end
 
-    unless AuthToken.valid? token
+  def verify_jwt_token
+    unless AuthToken.valid? user_token
       render json: { message: 'Authentication failed' }, status: :unauthorized
     end
   end
@@ -26,5 +28,9 @@ class ApplicationController < ActionController::Base
   def extract_token_from_headers(headers)
     auth_headers = headers['Authentication'] || ''
     auth_headers.split(' ').last
+  end
+
+  def current_person
+    AuthToken.user_from_token(user_token).role
   end
 end

--- a/app/services/auth_token.rb
+++ b/app/services/auth_token.rb
@@ -3,21 +3,25 @@ require 'jwt'
 class AuthToken
   attr_reader :token, :payload, :expiry
 
-  def initialize(payload, expiry: 168.hours.from_now)
+  def initialize(payload)
     @payload = payload
     @token = tokenize_payload
-    @expiry = expiry.to_i
   end
 
   def tokenize_payload
-    payload['exp'] = expiry
-    JWT.encode payload, Rails.application.secrets.secret_key_base
+    JWT.encode(payload, Rails.application.secrets.secret_key_base)
   end
 
   def self.valid?(token)
-    JWT.decode token, Rails.application.secrets.secret_key_base
-
+    JWT.decode(token, Rails.application.secrets.secret_key_base)
   rescue
     false
+  end
+
+  def self.user_from_token(token)
+    decoded = JWT.decode(token, Rails.application.secrets.secret_key_base)
+    data = decoded.first { |n| n['user'] }
+    email = data['user']['email']
+    User.find_by email: email
   end
 end

--- a/spec/api/experiences_spec.rb
+++ b/spec/api/experiences_spec.rb
@@ -28,6 +28,7 @@ describe Api::V1::ExperiencesController do
   describe '#get' do
     before(:all) { @exp = create :experience }
     before(:all) { get v1_experience_path(@exp), headers_for(:json) }
+    after { delete_db }
 
     it 'responds with 200 request (authenticated)' do
       authenticate_user
@@ -54,6 +55,8 @@ describe Api::V1::ExperiencesController do
 
   describe '#post' do
     let(:exp) { json :experience }
+    before { delete_db }
+    after { delete_db }
 
     context 'when user is authenticated' do
       before { authenticate_user }
@@ -62,6 +65,13 @@ describe Api::V1::ExperiencesController do
       it 'responds with 201 request (authenticated)' do
         expect(response).to have_http_status 201
       end
+
+      it 'creates the experience' do
+        experience_hash = JSON.parse(exp)['experience']
+
+        expect(Experience.count).to eq 1
+        expect(Experience.find_by(experience_hash)).to be_an Experience
+      end
     end
 
     context 'when user is unauthenticated' do
@@ -69,6 +79,10 @@ describe Api::V1::ExperiencesController do
 
       it 'responds with 401 request (unauthenticated)' do
         expect(response).to have_http_status 401
+      end
+
+      it 'does not create the experience' do
+        expect(Experience.count).to eq 0
       end
     end
   end

--- a/spec/api/experiences_spec.rb
+++ b/spec/api/experiences_spec.rb
@@ -5,7 +5,7 @@ describe Api::V1::ExperiencesController do
     after { delete_db }
 
     it 'responds with 200 request (authenticated)' do
-      allow(AuthToken).to receive(:valid?).and_return true
+      authenticate_user
 
       expect(response).to have_http_status 200
     end
@@ -30,7 +30,7 @@ describe Api::V1::ExperiencesController do
     before(:all) { get v1_experience_path(@exp), headers_for(:json) }
 
     it 'responds with 200 request (authenticated)' do
-      allow(AuthToken).to receive(:valid?).and_return true
+      authenticate_user
 
       expect(response).to have_http_status 200
     end

--- a/spec/api/experiences_spec.rb
+++ b/spec/api/experiences_spec.rb
@@ -51,4 +51,25 @@ describe Api::V1::ExperiencesController do
       end
     end
   end
+
+  describe '#post' do
+    let(:exp) { json :experience }
+
+    context 'when user is authenticated' do
+      before { authenticate_user }
+      before { post v1_experiences_path, exp, headers_for(:json) }
+
+      it 'responds with 201 request (authenticated)' do
+        expect(response).to have_http_status 201
+      end
+    end
+
+    context 'when user is unauthenticated' do
+      before { post v1_experiences_path, exp }
+
+      it 'responds with 401 request (unauthenticated)' do
+        expect(response).to have_http_status 401
+      end
+    end
+  end
 end

--- a/spec/api/sessions_spec.rb
+++ b/spec/api/sessions_spec.rb
@@ -32,7 +32,7 @@ describe Api::V1::SessionsController do
 
   describe '#logout' do
     it 'responds with 204 HTTP status with valid JWT' do
-      allow(AuthToken).to receive(:valid?).and_return true
+      authenticate_user
       delete v1_logout_path, {}, headers_for(:json)
 
       expect(response).to have_http_status 204

--- a/spec/services/auth_token_spec.rb
+++ b/spec/services/auth_token_spec.rb
@@ -1,5 +1,16 @@
 describe AuthToken do
-  let(:payload) { { test: true, data: 'test' } }
+  after { delete_db }
+
+  let(:user) { create :user }
+  let(:payload) do
+    {
+      'user' => {
+        'email' => user.email,
+        'password' => user.password
+      }
+    }
+  end
+
   subject { AuthToken.new payload }
 
   describe '#tokenize_payload' do
@@ -8,10 +19,18 @@ describe AuthToken do
     end
   end
 
-  describe '#valid' do
-    it 'becomes invalid after expiry' do
-      token = AuthToken.new(payload, expiry: 48.hours.ago)
-      expect(AuthToken.valid?(token)).to eq false
+  describe '.valid' do
+    it 'decodes the payload' do
+      expect(AuthToken.valid?(subject.token)).to include payload
+    end
+  end
+
+  describe '.user_from_token' do
+    it 'extracts the user' do
+      found_user = AuthToken.user_from_token(subject.token)
+
+      expect(found_user).to be_a User
+      expect(found_user.email).to eq user.email
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,5 +9,7 @@ RSpec.configure do |config|
 
   def authenticate_user
     allow(AuthToken).to receive(:valid?).and_return true
+    allow_any_instance_of(ApplicationController).to receive(:current_person)
+      .and_return(create(:person))
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,4 +6,8 @@ RSpec.configure do |config|
   config.mock_with :rspec do |mocks|
     mocks.verify_partial_doubles = true
   end
+
+  def authenticate_user
+    allow(AuthToken).to receive(:valid?).and_return true
+  end
 end


### PR DESCRIPTION
This PR allows for a user to POST /v1/experiences to create and experience.
Pretty simple. Once I implement experience_times, most of the logic in the
experiences controller will be pulled into a service object which will be
able to create experiences and associated experience times with one query.