### PR TITLE
Render errors to the client and clean up auth

### DIFF
--- a/app/controllers/api/v1/experiences_controller.rb
+++ b/app/controllers/api/v1/experiences_controller.rb
@@ -1,6 +1,6 @@
 module Api
   module V1
-    class ExperiencesController < ApplicationController
+    class ExperiencesController < ApiController
       before_filter :verify_jwt_token, except: [:show, :index]
       before_action :set_experience, only: [:show, :edit, :update, :destroy]
       respond_to :json
@@ -16,6 +16,9 @@ module Api
 
       def destroy
         @experience.destroy
+
+        # We respond with no_content regardless as to not give any extra
+        # information about the existence of the resource.
         head :no_content
       end
 
@@ -25,7 +28,7 @@ module Api
         if @experience.save
           render json: @experience, status: :created
         else
-          render json: @experience.errors, status: :unprocessable_entity
+          render json: errors_for(@experience), status: :unprocessable_entity
         end
       end
 

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -5,17 +5,8 @@ class ApiController < ApplicationController
 
   protected
 
-  def user_token
-    extract_token_from_headers request.headers
-  end
-
-  def extract_token_from_headers(headers)
-    auth_headers = headers['Authentication'] || ''
-    auth_headers.split(' ').last
-  end
-
   def verify_jwt_token
-    unless TokenAuthenticator.call user_token
+    unless RequestAuthenticator.call request.headers
       render json: { errors: 'Authentication failed' }, status: :unauthorized
     end
   end

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -1,0 +1,26 @@
+class ApiController < ApplicationController
+  before_action :configure_permitted_parameters, if: :devise_controller?
+  respond_to :json
+  skip_before_action :verify_authenticity_token, if: :json_request?
+
+  protected
+
+  def user_token
+    extract_token_from_headers request.headers
+  end
+
+  def extract_token_from_headers(headers)
+    auth_headers = headers['Authentication'] || ''
+    auth_headers.split(' ').last
+  end
+
+  def verify_jwt_token
+    unless TokenAuthenticator.call user_token
+      render json: { errors: 'Authentication failed' }, status: :unauthorized
+    end
+  end
+
+  def errors_for(model)
+    { errors: model.errors.full_messages }
+  end
+end

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -6,7 +6,7 @@ class ApiController < ApplicationController
   protected
 
   def verify_jwt_token
-    unless RequestAuthenticator.call request.headers
+    unless RequestAuthenticator.call request
       render json: { errors: 'Authentication failed' }, status: :unauthorized
     end
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,6 +16,6 @@ class ApplicationController < ActionController::Base
   end
 
   def current_person
-    TokenAuthenticator.user_from_token(user_token).role
+    RequestAuthenticator.user_from_token(user_token).role
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -15,21 +15,6 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  def user_token
-    extract_token_from_headers request.headers
-  end
-
-  def verify_jwt_token
-    unless TokenAuthenticator.call user_token
-      render json: { message: 'Authentication failed' }, status: :unauthorized
-    end
-  end
-
-  def extract_token_from_headers(headers)
-    auth_headers = headers['Authentication'] || ''
-    auth_headers.split(' ').last
-  end
-
   def current_person
     TokenAuthenticator.user_from_token(user_token).role
   end

--- a/app/services/request_authenticator.rb
+++ b/app/services/request_authenticator.rb
@@ -1,16 +1,20 @@
 class RequestAuthenticator
   class << self
-    def call(headers)
-      token = extract_token_from_headers(headers)
-      JWT.decode(token, Rails.application.secrets.secret_key_base)
-    rescue
-      false
+    def call(request)
+      token = extract_token_from_request request
+      token_valid? token
     end
 
     private
 
-    def extract_token_from_headers(headers)
-      auth_headers = headers['Authentication'] || ''
+    def token_valid?(token)
+      JWT.decode token, Rails.application.secrets.secret_key_base
+    rescue
+      false
+    end
+
+    def extract_token_from_request(request)
+      auth_headers = request.headers['Authentication'] || ''
       auth_headers.split(' ').last
     end
   end

--- a/app/services/request_authenticator.rb
+++ b/app/services/request_authenticator.rb
@@ -1,0 +1,17 @@
+class RequestAuthenticator
+  class << self
+    def call(headers)
+      token = extract_token_from_headers(headers)
+      JWT.decode(token, Rails.application.secrets.secret_key_base)
+    rescue
+      false
+    end
+
+    private
+
+    def extract_token_from_headers(headers)
+      auth_headers = headers['Authentication'] || ''
+      auth_headers.split(' ').last
+    end
+  end
+end

--- a/app/services/token_authenticator.rb
+++ b/app/services/token_authenticator.rb
@@ -1,7 +1,0 @@
-class TokenAuthenticator
-  def self.call(token)
-    JWT.decode(token, Rails.application.secrets.secret_key_base)
-  rescue
-    false
-  end
-end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -10,4 +10,5 @@ Devise.setup do |config|
   config.password_length = 8..128
   config.reset_password_within = 6.hours
   config.sign_out_via = :delete
+  config.parent_controller = 'ApiController'
 end

--- a/spec/api/experiences_spec.rb
+++ b/spec/api/experiences_spec.rb
@@ -71,21 +71,26 @@ describe Api::V1::ExperiencesController do
   describe 'POST #create' do
     let(:exp) { json :experience }
 
-    before do
-      allow_any_instance_of(Experience).to receive(:save).and_return true
-    end
-
     context 'when user is authenticated' do
       before { authenticate_user }
 
       it 'responds with 201 request (authenticated)' do
+        allow_any_instance_of(Experience).to receive(:save)
+          .and_return true
         post v1_experiences_path, exp, headers_for(:json)
+
         expect(response).to have_http_status 201
       end
 
       it 'creates the experience' do
         expect_any_instance_of(Experience).to receive(:save) { true }
         post v1_experiences_path, exp, headers_for(:json)
+      end
+
+      it 'renders errors in a consumable format' do
+        invalid_exp = { experience: { name: 'Test' } }.to_json
+        post v1_experiences_path, invalid_exp, headers_for(:json)
+        expect(response_body).to include :errors
       end
     end
 

--- a/spec/services/request_authenticator_spec.rb
+++ b/spec/services/request_authenticator_spec.rb
@@ -3,7 +3,7 @@ describe RequestAuthenticator do
 
   let(:payload) { login_hash :user }
   let(:token) { TokenCreator.call payload }
-  let(:headers) { { 'Authentication' => "Bearer #{token}" } }
+  let(:headers) { OpenStruct.new headers: { 'Authentication' => "Bearer #{token}" } }
 
   subject { RequestAuthenticator.call headers }
 

--- a/spec/services/request_authenticator_spec.rb
+++ b/spec/services/request_authenticator_spec.rb
@@ -1,10 +1,11 @@
-describe TokenAuthenticator do
+describe RequestAuthenticator do
   after { delete_db }
 
   let(:payload) { login_hash :user }
   let(:token) { TokenCreator.call payload }
+  let(:headers) { { 'Authentication' => "Bearer #{token}" } }
 
-  subject { TokenAuthenticator.call token }
+  subject { RequestAuthenticator.call headers }
 
   describe '.call' do
     it 'decodes the payload' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,7 +8,7 @@ RSpec.configure do |config|
   end
 
   def authenticate_user
-    allow(TokenAuthenticator).to receive(:call).and_return true
+    allow(RequestAuthenticator).to receive(:call).and_return true
     allow_any_instance_of(ApplicationController).to receive(:current_person)
       .and_return(create(:person))
   end


### PR DESCRIPTION
As of this request, we render some good messages to the client when there is an error with POST experiences. Also, I have altered some logic to create a RequestAuthenticator service, which deals with the whole responsibility of authenticating a request. What this means from an implementation standpoint is that RequestAuthenticator receives a request object now as opposed to a token.