### PR TITLE
update boot.rb to listen on host 0.0.0.0 rather than localhost and updat...

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,11 @@ REST API for the Tuxedio experience marketplace.
 
 1. Install [Neo4j](http://neo4j.com/docs/stable/server-installation.html)
   * Note: make sure to start the Neo4j server
-2. Install the bundles
+2. Install mailcatcher gem and run the daemon
+  `$ gem install mailcatcher && mailcatcher`
+3. Install the bundles
   `$ bundle install`
-3. Run the tests
+4. Run the tests
   `$ rspec`
 
 ## Coding Style

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -2,3 +2,16 @@
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
 
 require 'bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE'])
+
+# Fix for rails not listening on 0.0.0.0
+require 'rubygems'
+require 'rails/commands/server'
+
+module Rails
+  class Server
+    alias_method :default_options_alias, :default_options
+    def default_options
+      default_options_alias.merge!(Host: '0.0.0.0')
+    end
+  end
+end


### PR DESCRIPTION
...e readme to include mailcatcher

Does as it says. @ianks found this solution, not sure if it is a good thing to do so I figure you should look over it first, but this saves the hassle of `rails s -b 0.0.0.0` when running the server