### PR TITLE
Optimize query for experiences

### DIFF
--- a/app/serializers/experience_serializer.rb
+++ b/app/serializers/experience_serializer.rb
@@ -1,6 +1,3 @@
 class ExperienceSerializer < ActiveModel::Serializer
   attributes :id, :name, :location, :description
-
-  has_one :host
-  has_many :times
 end


### PR DESCRIPTION
Active Model Serializers was generating an n+1 query that was super non-performant. Remove that for now.